### PR TITLE
Fix unicode paths on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   FetchContent_Declare(
     FLAC
     GIT_REPOSITORY  https://gitlab.xiph.org/xiph/flac.git
-    GIT_TAG         27c615706cedd252a206dd77e3910dfa395dcc49
+    GIT_TAG         c2daa371041305ffa85bef7d32b97c93890c696e
   )
 
   option(WITH_OGG YES)

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,3 +1,6 @@
-const api = require('bindings')('flac-bindings')
+const bindings = require('bindings')
+
+const moduleRoot = bindings.getRoot(__filename)
+const api = bindings({ bindings: 'flac-bindings.node', module_root: moduleRoot })
 
 module.exports = api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flac-bindings",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "libflac": "1.3.3",
   "libogg": "1.3.4",
   "description": "libflac bindings to node.js with easy to use API",


### PR DESCRIPTION
When using `FileDecoder` and `FileEncoder` objects (or the almost-low-level APIs `StreamDecoder` and `StreamEncoder` with a `initWithFile`/`initWithOggFile` methods) on Windows, uses `fopen` to open the files. But `fopen` on Windows does not understand non-ascii characters in the path.

The PR uses custom open mechanism for the low level API, in which in Windows converts the UTF-8 string into UTF-16 to use `_wfopen_s` to open the file (the Wide String version of `fopen_s`) which supports paths with Unicode characters.

This PR does not fix for other APIs like in Metadata due to limitations in the FLAC C API.

Fixes #37 
