### PR TITLE
Do not destroy stream on decode error cbk called

### DIFF
--- a/lib/decoder/file-decoder.d.ts
+++ b/lib/decoder/file-decoder.d.ts
@@ -12,6 +12,7 @@ export interface FileDecoderOptions extends DecoderOptions {
  * a interleaved raw PCM stream.
  * @emits metadata When a metadata block is received, the event will be fired
  * @emits format When the decoder knows the exact format of the flac
+ * @emits flac-error When the decoder found an error
  */
 export default class FileDecoder extends Readable implements BaseDecoder {
   constructor(options: FileDecoderOptions);

--- a/lib/decoder/file-decoder.js
+++ b/lib/decoder/file-decoder.js
@@ -195,11 +195,10 @@ class FileDecoder extends Readable {
     this.emit('metadata', metadata)
   }
 
-  _errorCbk(error) {
-    const errorObj = new Error(flac.Decoder.ErrorStatusString[error])
-    errorObj.code = error
-    this._debug(`Decoder called error callback ${error}`)
-    this.destroy(errorObj)
+  _errorCbk(code) {
+    const message = new Error(flac.Decoder.ErrorStatusString[code])
+    this._debug(`Decoder called error callback ${code} (${message})`)
+    this.emit('flac-error', { code, message })
   }
 
   _throwDecoderError() {

--- a/lib/decoder/stream-decoder.d.ts
+++ b/lib/decoder/stream-decoder.d.ts
@@ -6,6 +6,7 @@ import { BaseDecoder, DecoderOptions, DecoderPosition } from './interfaces'
  * a interleaved raw PCM stream.
  * @emits metadata When a metadata block is received, the event will be fired
  * @emits format When the decoder knows the exact format of the flac
+ * @emits flac-error When the decoder found an error
  */
 export default class StreamDecoder extends Transform implements BaseDecoder {
   constructor(props: DecoderOptions)

--- a/lib/decoder/stream-decoder.js
+++ b/lib/decoder/stream-decoder.js
@@ -284,11 +284,10 @@ class StreamDecoder extends stream.Transform {
     this.emit('metadata', metadata)
   }
 
-  _errorCbk(error) {
-    const errorObj = new Error(flac.Decoder.ErrorStatusString[error])
-    errorObj.code = error
-    this._debug(`Decoder called error callback ${error}`)
-    throw errorObj
+  _errorCbk(code) {
+    const message = new Error(flac.Decoder.ErrorStatusString[code])
+    this._debug(`Decoder called error callback ${code} (${message})`)
+    this.emit('flac-error', { code, message })
   }
 
   _throwDecoderError() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flac-bindings",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "libflac": "1.3.3",
   "libogg": "1.3.4",
   "description": "libflac bindings to node.js with easy to use API",


### PR DESCRIPTION
If the decoder calls the error callback in StreamDecoder or FileDecoder,
now it will only emit `flac-error` instead of destroying the stream (and
emitting `error`). It will continue to decode unless the decoder finds a
fatal error.

See #40 